### PR TITLE
Remove Autosar Builder from the list of prototypes

### DIFF
--- a/content/tools.md
+++ b/content/tools.md
@@ -43,4 +43,4 @@ The overview classifies each tool w.r.t. its support for the different container
 
 &nbsp;
 
-There are a few tools with prototype support for eFMI, but not yet released; these are, in alphabetic order: [Astrée](https://www.absint.com/astree/index.htm), [AUTOSAR Builder](https://www.3ds.com/products-services/catia/products/autosar-builder/), [Simcenter Amesim](https://plm.sw.siemens.com/en-US/simcenter/systems-simulation/amesim/) and [SimulationX](https://www.esi-group.com/products/simulationx). If you are a user of these tools and are interested in eFMI, please push the respective developers to bring their prototypes to an official release.
+There are a few tools with prototype support for eFMI, but not yet released; these are, in alphabetic order: [Astrée](https://www.absint.com/astree/index.htm),  [Simcenter Amesim](https://plm.sw.siemens.com/en-US/simcenter/systems-simulation/amesim/) and [SimulationX](https://www.esi-group.com/products/simulationx). If you are a user of these tools and are interested in eFMI, please push the respective developers to bring their prototypes to an official release.


### PR DESCRIPTION
Autosar Builder is already in the list of released tools.
So, I propose to remove it from the list of prototype implementations.